### PR TITLE
✨ Feat/#7 Tab 컴포넌트(TwoTab, FourTab) 구현

### DIFF
--- a/components/Tab/FourTab/FourTab.module.scss
+++ b/components/Tab/FourTab/FourTab.module.scss
@@ -1,0 +1,34 @@
+.tabContainer {
+  display: flex;
+  position: relative;
+  width: 100%;
+}
+
+.tab {
+  flex: 1;
+  padding: 8px;
+  cursor: pointer;
+  transition: color 0.3s ease;
+
+  &.active {
+    font-weight: 500;
+    color: black;
+  }
+  color: var(--color-gray-1);
+}
+
+.indicator {
+  position: absolute;
+  bottom: 0;
+  width: 25%;
+  height: 2px;
+  background-color: black;
+  transition: transform 0.3s ease;
+
+  &[data-selected="second"] {
+    transform: translateX(100%);
+  }
+  &[data-selected="first"] {
+    transform: translateX(0%);
+  }
+}

--- a/components/Tab/FourTab/FourTab.tsx
+++ b/components/Tab/FourTab/FourTab.tsx
@@ -1,0 +1,41 @@
+"use client"; // 클라이언트 컴포넌트
+
+import { useRouter } from "next/navigation";
+import styles from "./FourTab.module.scss";
+
+interface FourTabProps {
+  options: string[];
+  selectedTab: string;
+}
+
+const FourTab = ({ options, selectedTab }: FourTabProps) => {
+  const router = useRouter();
+
+  const handleTabClick = (tab: string) => {
+    if (tab !== selectedTab) {
+      router.push(`?tab=${encodeURIComponent(tab)}`, { scroll: false });
+    }
+  };
+
+  return (
+    <div className={styles.tabContainer}>
+      {options.map((tab) => (
+        <button
+          key={tab}
+          className={`${styles.tab} ${selectedTab === tab ? styles.active : ""}`}
+          onClick={() => handleTabClick(tab)}
+        >
+          {tab}
+        </button>
+      ))}
+      <div
+        className={styles.indicator}
+        style={{
+          transform: `translateX(${options.indexOf(selectedTab) * 100}%)`,
+        }}
+      />
+    </div>
+  );
+};
+
+export default FourTab;

--- a/components/Tab/TwoTab/TwoTab.module.scss
+++ b/components/Tab/TwoTab/TwoTab.module.scss
@@ -1,0 +1,34 @@
+.tabContainer {
+  display: flex;
+  position: relative;
+  width: 100%;
+}
+
+.tab {
+  flex: 1;
+  padding: 8px;
+  cursor: pointer;
+  transition: color 0.3s ease;
+
+  &.active {
+    font-weight: 500;
+    color: black;
+  }
+  color: var(--color-gray-1);
+}
+
+.indicator {
+  position: absolute;
+  bottom: 0;
+  width: 50%;
+  height: 2px;
+  background-color: black;
+  transition: transform 0.3s ease;
+
+  &[data-selected="second"] {
+    transform: translateX(100%);
+  }
+  &[data-selected="first"] {
+    transform: translateX(0%);
+  }
+}

--- a/components/Tab/TwoTab/TwoTab.tsx
+++ b/components/Tab/TwoTab/TwoTab.tsx
@@ -1,0 +1,41 @@
+"use client"; // 클라이언트 컴포넌트로 설정
+
+import { useRouter } from "next/navigation";
+import styles from "./TwoTab.module.scss";
+
+interface TwoTabProps {
+  options: [string, string];
+  selectedTab: string;
+}
+
+const TwoTab = ({ options, selectedTab }: TwoTabProps) => {
+  const router = useRouter();
+
+  const handleTabClick = (tab: string) => {
+    if (tab !== selectedTab) {
+      router.push(`?tab=${encodeURIComponent(tab)}`, { scroll: false });
+    }
+  };
+
+  return (
+    <div className={styles.tabContainer}>
+      {options.map((tab) => (
+        <button
+          key={tab}
+          className={`${styles.tab} ${selectedTab === tab ? styles.active : ""}`}
+          onClick={() => handleTabClick(tab)}
+        >
+          {tab}
+        </button>
+      ))}
+      <div
+        className={styles.indicator}
+        style={{
+          transform: `translateX(${selectedTab === options[1] ? "100%" : "0%"})`,
+        }}
+      />
+    </div>
+  );
+};
+
+export default TwoTab;


### PR DESCRIPTION
### 👀 관련 이슈

Tab 컴포넌트 만듦

### ✨ 작업한 내용
SSR 페이지에서도 사용해야하니까, props로 전달할 수 없는게 있음
그래서 params를 이용해야 합니다..
아래 사용법 예시 참고하시길

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

**1) TwoTab 사용법**
```
import TwoTab from "@/components/Tab/TwoTab/TwoTab";
import styles from "../page.module.scss";

interface HomePageProps {
  searchParams?: { tab?: string };
}

export default function HomePage({ searchParams }: HomePageProps) {
  const selectedTab = searchParams?.tab === "예약" ? "예약" : "하트";

  return (
    <div className={styles.page}>
      <TwoTab options={["하트", "예약/대기"]} selectedTab={selectedTab} />
    </div>
  );
}
```

**2) FourTab 사용법**
```
import FourTab from "@/components/Tab/FourTab/FourTab";
import styles from "../page.module.scss";

interface HomePageProps {
  searchParams?: { tab?: string };
}

export default function HomePage({ searchParams }: HomePageProps) {
  const tabs = ["찜", "예약/대기", "완료", "취소"]; // 4개의 탭 옵션
  const selectedTab = tabs.includes(searchParams?.tab || "")
    ? searchParams!.tab!
    : "찜";

  return (
    <div className={styles.page}>
      <FourTab options={tabs} selectedTab={selectedTab} />
    </div>
  );
}

```

### 📷 스크린샷 또는 GIF
