### PR TITLE
✨ Feat/#29 바텀시트 구현

### DIFF
--- a/components/BottomSheet/BottomSheet.module.scss
+++ b/components/BottomSheet/BottomSheet.module.scss
@@ -1,0 +1,42 @@
+.bottomSheet {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 100%;
+  background-color: var(--color-white);
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+}
+
+.dragHandle {
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.handleBar {
+  width: 120px;
+  height: 4px;
+  background-color: var(--color-gray-2);
+  border-radius: 2px;
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 16px;
+
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.content::-webkit-scrollbar {
+  display: none;
+}

--- a/components/BottomSheet/BottomSheet.module.scss
+++ b/components/BottomSheet/BottomSheet.module.scss
@@ -1,9 +1,9 @@
 .bottomSheet {
   position: absolute;
+  height: 100%;
   left: 0;
   right: 0;
   bottom: 0;
-  height: 100%;
   background-color: var(--color-white);
   box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
   transition: transform 0.3s ease;

--- a/components/BottomSheet/BottomSheet.tsx
+++ b/components/BottomSheet/BottomSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
 import styles from "./BottomSheet.module.scss";
+import React, { useState, useEffect, useRef } from "react";
 
 type SheetState = "closed" | "min" | "middle" | "open";
 

--- a/components/BottomSheet/BottomSheet.tsx
+++ b/components/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React, { useState, useEffect, useRef } from "react";
+import styles from "./BottomSheet.module.scss";
+
+type SheetState = "closed" | "min" | "middle" | "open";
+
+interface BottomSheetProps {
+  children?: React.ReactNode;
+}
+
+const BottomSheet: React.FC<BottomSheetProps> = ({ children }) => {
+  const [sheetState, setSheetState] = useState<SheetState>("min");
+  const sheetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (sheetState !== "closed") {
+      const handleOutsideClick = (e: MouseEvent) => {
+        if (sheetRef.current && !sheetRef.current.contains(e.target as Node)) {
+          setSheetState("closed");
+        }
+      };
+      document.addEventListener("click", handleOutsideClick);
+      return () => {
+        document.removeEventListener("click", handleOutsideClick);
+      };
+    }
+  }, [sheetState]);
+
+  const handleContainerClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    if (sheetState === "min" || sheetState === "middle") {
+      setSheetState("open");
+    }
+  };
+
+  // 닫힘 → min, min ↔ middle, open → min
+  const handleDragHandleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    if (sheetState === "closed") {
+      setSheetState("min");
+    } else if (sheetState === "min") {
+      setSheetState("middle");
+    } else if (sheetState === "middle") {
+      setSheetState("min");
+    } else if (sheetState === "open") {
+      setSheetState("min");
+    }
+  };
+
+  let transformStyle = "";
+  switch (sheetState) {
+    case "open":
+      transformStyle = "translateY(8%)";
+      break;
+    case "min":
+      transformStyle = "translateY(60%)";
+      break;
+    case "middle":
+      transformStyle = "translateY(30%)";
+      break;
+    case "closed":
+      transformStyle = "translateY(calc(100% - 40px))";
+      break;
+    default:
+      transformStyle = "translateY(60%)";
+  }
+
+  return (
+    <div
+      ref={sheetRef}
+      className={styles.bottomSheet}
+      style={{ transform: transformStyle }}
+      onClick={handleContainerClick}
+    >
+      <div className={styles.dragHandle} onClick={handleDragHandleClick}>
+        <div className={styles.handleBar}></div>
+      </div>
+      {(sheetState === "min" ||
+        sheetState === "middle" ||
+        sheetState === "open") && (
+        <div className={styles.content}>{children}</div>
+      )}
+    </div>
+  );
+};
+
+export default BottomSheet;


### PR DESCRIPTION
### 👀 관련 이슈
#29
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용
바텀시트 구현
<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항
웹으로 볼 경우 드래그 하기가 어려운 것 같아서 기본 상태일 경우 드래그 핸들로 오픈하거나 닫을 수 있지만 그 외의 경우 외부 레이아웃 클릭 시 닫히고, 내부 바텀시트 클릭 시 더 열리도록 구현되어있습니다. 
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|  바텀시트  |  ![바텀시트](https://github.com/user-attachments/assets/00ceec56-96e8-488e-9f75-25f93aaa49be)  |
