### PR TITLE
🐛 Fix/#52 기존 바텀시트 액션/동작방식 수정

### DIFF
--- a/components/BottomSheet/BottomSheet.module.scss
+++ b/components/BottomSheet/BottomSheet.module.scss
@@ -1,12 +1,11 @@
 .bottomSheet {
   position: absolute;
-  height: 100%;
+  bottom: 0;
   left: 0;
   right: 0;
-  bottom: 0;
   background-color: var(--color-white);
   box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease;
+  transition: height 0.3s ease;
   display: flex;
   flex-direction: column;
   z-index: 1000;
@@ -32,7 +31,6 @@
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding: 16px;
-
   scrollbar-width: none;
   -ms-overflow-style: none;
 }

--- a/components/BottomSheet/BottomSheet.tsx
+++ b/components/BottomSheet/BottomSheet.tsx
@@ -3,14 +3,14 @@
 import styles from "./BottomSheet.module.scss";
 import React, { useState, useEffect, useRef } from "react";
 
-type SheetState = "closed" | "min" | "middle" | "open";
+type SheetState = "closed" | "middle" | "open";
 
 interface BottomSheetProps {
   children?: React.ReactNode;
 }
 
 const BottomSheet: React.FC<BottomSheetProps> = ({ children }) => {
-  const [sheetState, setSheetState] = useState<SheetState>("min");
+  const [sheetState, setSheetState] = useState<SheetState>("middle");
   const sheetRef = useRef<HTMLDivElement>(null);
 
   const [dragging, setDragging] = useState(false);
@@ -34,7 +34,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({ children }) => {
 
   const handleContainerClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
-    if (sheetState === "min" || sheetState === "middle") {
+    if (sheetState === "middle") {
       setSheetState("open");
     }
   };
@@ -72,21 +72,17 @@ const BottomSheet: React.FC<BottomSheetProps> = ({ children }) => {
 
     const H = window.innerHeight;
     const closedHeight = 40;
-    const minHeight = H * 0.4;
-    const middleHeight = H * 0.7;
+    const middleHeight = H * 0.4;
     const openHeight = H * 0.92;
 
     const diffClosed = Math.abs(newHeight - closedHeight);
-    const diffMin = Math.abs(newHeight - minHeight);
     const diffMiddle = Math.abs(newHeight - middleHeight);
     const diffOpen = Math.abs(newHeight - openHeight);
 
-    let finalState: SheetState = "min";
-    const minDiff = Math.min(diffClosed, diffMin, diffMiddle, diffOpen);
+    let finalState: SheetState = "middle";
+    const minDiff = Math.min(diffClosed, diffMiddle, diffOpen);
     if (minDiff === diffClosed) {
       finalState = "closed";
-    } else if (minDiff === diffMin) {
-      finalState = "min";
     } else if (minDiff === diffMiddle) {
       finalState = "middle";
     } else if (minDiff === diffOpen) {
@@ -113,6 +109,17 @@ const BottomSheet: React.FC<BottomSheetProps> = ({ children }) => {
     };
   }, [dragging, startY, startHeight]);
 
+  const handleDragHandleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    if (sheetState === "closed") {
+      setSheetState("middle");
+    } else if (sheetState === "middle") {
+      setSheetState("closed");
+    } else if (sheetState === "open") {
+      setSheetState("middle");
+    }
+  };
+
   const windowHeight = typeof window !== "undefined" ? window.innerHeight : 0;
   let heightValue = "";
   switch (sheetState) {
@@ -120,9 +127,6 @@ const BottomSheet: React.FC<BottomSheetProps> = ({ children }) => {
       heightValue = windowHeight ? `${windowHeight * 0.92}px` : "92%";
       break;
     case "middle":
-      heightValue = windowHeight ? `${windowHeight * 0.7}px` : "70%";
-      break;
-    case "min":
       heightValue = windowHeight ? `${windowHeight * 0.4}px` : "40%";
       break;
     case "closed":
@@ -145,12 +149,11 @@ const BottomSheet: React.FC<BottomSheetProps> = ({ children }) => {
           className={styles.dragHandle}
           onMouseDown={handleDragStart}
           onTouchStart={handleDragStart}
+          onClick={handleDragHandleClick}
         >
           <div className={styles.handleBar}></div>
         </div>
-        {(sheetState === "min" ||
-          sheetState === "middle" ||
-          sheetState === "open") && (
+        {(sheetState === "middle" || sheetState === "open") && (
           <div className={styles.content}>{children}</div>
         )}
       </div>

--- a/components/BottomSheet/BottomSheet.tsx
+++ b/components/BottomSheet/BottomSheet.tsx
@@ -13,6 +13,11 @@ const BottomSheet: React.FC<BottomSheetProps> = ({ children }) => {
   const [sheetState, setSheetState] = useState<SheetState>("min");
   const sheetRef = useRef<HTMLDivElement>(null);
 
+  const [dragging, setDragging] = useState(false);
+  const [startY, setStartY] = useState<number | null>(null);
+  const [startHeight, setStartHeight] = useState<number>(0);
+  const [dragHeight, setDragHeight] = useState<number | null>(null);
+
   useEffect(() => {
     if (sheetState !== "closed") {
       const handleOutsideClick = (e: MouseEvent) => {
@@ -34,53 +39,121 @@ const BottomSheet: React.FC<BottomSheetProps> = ({ children }) => {
     }
   };
 
-  // 닫힘 → min, min ↔ middle, open → min
-  const handleDragHandleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleDragStart = (
+    e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>
+  ) => {
     e.stopPropagation();
-    if (sheetState === "closed") {
-      setSheetState("min");
-    } else if (sheetState === "min") {
-      setSheetState("middle");
-    } else if (sheetState === "middle") {
-      setSheetState("min");
-    } else if (sheetState === "open") {
-      setSheetState("min");
-    }
+    const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
+    setDragging(true);
+    setStartY(clientY);
+    const currentHeight = sheetRef.current?.getBoundingClientRect().height || 0;
+    setStartHeight(currentHeight);
   };
 
-  let transformStyle = "";
+  const handleDragMove = (e: MouseEvent | TouchEvent) => {
+    if (!dragging || startY === null) return;
+    const clientY =
+      "touches" in e
+        ? (e as TouchEvent).touches[0].clientY
+        : (e as MouseEvent).clientY;
+    const delta = startY - clientY;
+    const newHeight = Math.max(40, startHeight + delta);
+    setDragHeight(newHeight);
+  };
+
+  const handleDragEnd = (e: MouseEvent | TouchEvent) => {
+    if (!dragging || startY === null) return;
+    const clientY =
+      "changedTouches" in e
+        ? (e as TouchEvent).changedTouches[0].clientY
+        : (e as MouseEvent).clientY;
+    const delta = startY - clientY;
+    const newHeight = Math.max(40, startHeight + delta);
+
+    const H = window.innerHeight;
+    const closedHeight = 40;
+    const minHeight = H * 0.4;
+    const middleHeight = H * 0.7;
+    const openHeight = H * 0.92;
+
+    const diffClosed = Math.abs(newHeight - closedHeight);
+    const diffMin = Math.abs(newHeight - minHeight);
+    const diffMiddle = Math.abs(newHeight - middleHeight);
+    const diffOpen = Math.abs(newHeight - openHeight);
+
+    let finalState: SheetState = "min";
+    const minDiff = Math.min(diffClosed, diffMin, diffMiddle, diffOpen);
+    if (minDiff === diffClosed) {
+      finalState = "closed";
+    } else if (minDiff === diffMin) {
+      finalState = "min";
+    } else if (minDiff === diffMiddle) {
+      finalState = "middle";
+    } else if (minDiff === diffOpen) {
+      finalState = "open";
+    }
+    setSheetState(finalState);
+    setDragging(false);
+    setStartY(null);
+    setDragHeight(null);
+  };
+
+  useEffect(() => {
+    if (dragging) {
+      document.addEventListener("mousemove", handleDragMove);
+      document.addEventListener("mouseup", handleDragEnd);
+      document.addEventListener("touchmove", handleDragMove);
+      document.addEventListener("touchend", handleDragEnd);
+    }
+    return () => {
+      document.removeEventListener("mousemove", handleDragMove);
+      document.removeEventListener("mouseup", handleDragEnd);
+      document.removeEventListener("touchmove", handleDragMove);
+      document.removeEventListener("touchend", handleDragEnd);
+    };
+  }, [dragging, startY, startHeight]);
+
+  const windowHeight = typeof window !== "undefined" ? window.innerHeight : 0;
+  let heightValue = "";
   switch (sheetState) {
     case "open":
-      transformStyle = "translateY(8%)";
-      break;
-    case "min":
-      transformStyle = "translateY(60%)";
+      heightValue = windowHeight ? `${windowHeight * 0.92}px` : "92%";
       break;
     case "middle":
-      transformStyle = "translateY(30%)";
+      heightValue = windowHeight ? `${windowHeight * 0.7}px` : "70%";
+      break;
+    case "min":
+      heightValue = windowHeight ? `${windowHeight * 0.4}px` : "40%";
       break;
     case "closed":
-      transformStyle = "translateY(calc(100% - 40px))";
+      heightValue = "40px";
       break;
     default:
-      transformStyle = "translateY(60%)";
+      heightValue = windowHeight ? `${windowHeight * 0.4}px` : "40%";
   }
+  const appliedHeight = dragHeight !== null ? `${dragHeight}px` : heightValue;
 
   return (
-    <div
-      ref={sheetRef}
-      className={styles.bottomSheet}
-      style={{ transform: transformStyle }}
-      onClick={handleContainerClick}
-    >
-      <div className={styles.dragHandle} onClick={handleDragHandleClick}>
-        <div className={styles.handleBar}></div>
+    <div className={styles.bottomSheetContainer}>
+      <div
+        ref={sheetRef}
+        className={styles.bottomSheet}
+        style={{ height: appliedHeight }}
+        onClick={handleContainerClick}
+      >
+        <div
+          className={styles.dragHandle}
+          onMouseDown={handleDragStart}
+          onTouchStart={handleDragStart}
+        >
+          <div className={styles.handleBar}></div>
+        </div>
+        {(sheetState === "min" ||
+          sheetState === "middle" ||
+          sheetState === "open") && (
+          <div className={styles.content}>{children}</div>
+        )}
       </div>
-      {(sheetState === "min" ||
-        sheetState === "middle" ||
-        sheetState === "open") && (
-        <div className={styles.content}>{children}</div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
### 👀 관련 이슈
#52
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용
기존 바텀시트의 4단계 오류를 3단계로 줄임
바텀시트 터치 이벤트 + 스크롤 이벤트 추가
<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point
닫힘, 중간단계(기본), 모두 열림 단계로 구분되어있으며 터치와 스크롤이... 그렇게 자연스럽진 않을 수도 있어요🥲
children에 따라 스크롤이 늘어나는 에러는 해결했습니다
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   바텀시트(수정)   |  ![bottomsheet](https://github.com/user-attachments/assets/483ee35d-9e87-45a8-aca0-d9a7ac00e6f0)  |
