### PR TITLE
🐛 Fix/#105 생카목록 지도뷰 스크롤 버그

### DIFF
--- a/app/member/list/_components/MapView/_components/Map/Map.module.scss
+++ b/app/member/list/_components/MapView/_components/Map/Map.module.scss
@@ -1,6 +1,6 @@
 .mapContainer {
   width: min(500px, 100vw);
-  height: calc(100svh - 112px - var(--margin-md));
+  height: calc(100svh - 150px);
   position: fixed;
   left: calc(-1 * (var(--margin-xl)));
   top: calc(-1 * (var(--margin-md)));

--- a/app/member/list/_components/MapView/_components/Map/Map.module.scss
+++ b/app/member/list/_components/MapView/_components/Map/Map.module.scss
@@ -1,6 +1,6 @@
 .mapContainer {
   width: min(500px, 100vw);
-  height: calc(100svh - 150px);
+  height: calc(100svh - 158px);
   position: fixed;
   left: calc(-1 * (var(--margin-xl)));
   top: calc(-1 * (var(--margin-md)));


### PR DESCRIPTION
### 👀 관련 이슈

close #105

### ✨ 작업한 내용

생카목록 지도뷰 스크롤 버그 해결

### 🌀 PR Point



### 🍰 참고사항



### 📷 스크린샷 또는 GIF

우측 스크롤 안생기게 변경   
<img width="852" alt="image" src="https://github.com/user-attachments/assets/3ff3cdd8-dda7-47f1-9a91-e16cf0a74818" />
      |
