### PR TITLE
✨ Feat/#146 코스 상세페이지 동선 그리기 기능 구현

### DIFF
--- a/app/member/course/[course_id]/page.tsx
+++ b/app/member/course/[course_id]/page.tsx
@@ -48,13 +48,18 @@ export default function CoursePage() {
   }, [course_id, setCourseEvent, courseEvent.length]);
 
   useEffect(() => {
-    const newMarkers = eventDetails.map((item) => ({
-      latitude: item.latitude,
-      longitude: item.longitude,
-      mainImage: item.imgSrc,
-    }));
-    setMarkers(newMarkers);
-  }, [eventDetails]);
+    if (eventDetails.length > 0 && courseEvent.length > 0) {
+      const sortedEvents = courseEvent
+        .map((id) => eventDetails.find((e) => e.id === id))
+        .filter((e): e is ShowCourseEventsDto => Boolean(e));
+      const newMarkers = sortedEvents.map((item) => ({
+        latitude: item.latitude,
+        longitude: item.longitude,
+        mainImage: item.imgSrc,
+      }));
+      setMarkers(newMarkers);
+    }
+  }, [eventDetails, courseEvent]);
 
   const handleOrderChange = useCallback(
     (newOrder: number[]) => {

--- a/components/BottomSheet/BottomSheet.tsx
+++ b/components/BottomSheet/BottomSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import styles from "./BottomSheet.module.scss";
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 
 type SheetState = "closed" | "middle" | "open";
 
@@ -55,49 +55,55 @@ const BottomSheet: React.FC<BottomSheetProps> = ({ children }) => {
     setStartHeight(currentHeight);
   };
 
-  const handleDragMove = (e: MouseEvent | TouchEvent) => {
-    if (!dragging || startY === null) return;
-    const clientY =
-      "touches" in e
-        ? (e as TouchEvent).touches[0].clientY
-        : (e as MouseEvent).clientY;
-    const delta = startY - clientY;
-    const newHeight = Math.max(40, startHeight + delta);
-    setDragHeight(newHeight);
-  };
+  const handleDragMove = useCallback(
+    (e: MouseEvent | TouchEvent) => {
+      if (!dragging || startY === null) return;
+      const clientY =
+        "touches" in e
+          ? (e as TouchEvent).touches[0].clientY
+          : (e as MouseEvent).clientY;
+      const delta = startY - clientY;
+      const newHeight = Math.max(40, startHeight + delta);
+      setDragHeight(newHeight);
+    },
+    [dragging, startY, startHeight]
+  );
 
-  const handleDragEnd = (e: MouseEvent | TouchEvent) => {
-    if (!dragging || startY === null) return;
-    const clientY =
-      "changedTouches" in e
-        ? (e as TouchEvent).changedTouches[0].clientY
-        : (e as MouseEvent).clientY;
-    const delta = startY - clientY;
-    const newHeight = Math.max(40, startHeight + delta);
+  const handleDragEnd = useCallback(
+    (e: MouseEvent | TouchEvent) => {
+      if (!dragging || startY === null) return;
+      const clientY =
+        "changedTouches" in e
+          ? (e as TouchEvent).changedTouches[0].clientY
+          : (e as MouseEvent).clientY;
+      const delta = startY - clientY;
+      const newHeight = Math.max(40, startHeight + delta);
 
-    const H = mounted ? window.innerHeight : 800;
-    const closedHeight = 40;
-    const middleHeight = H * 0.4;
-    const openHeight = H * 0.92;
+      const H = mounted ? window.innerHeight : 800;
+      const closedHeight = 40;
+      const middleHeight = H * 0.4;
+      const openHeight = H * 0.92;
 
-    const diffClosed = Math.abs(newHeight - closedHeight);
-    const diffMiddle = Math.abs(newHeight - middleHeight);
-    const diffOpen = Math.abs(newHeight - openHeight);
+      const diffClosed = Math.abs(newHeight - closedHeight);
+      const diffMiddle = Math.abs(newHeight - middleHeight);
+      const diffOpen = Math.abs(newHeight - openHeight);
 
-    let finalState: SheetState = "middle";
-    const minDiff = Math.min(diffClosed, diffMiddle, diffOpen);
-    if (minDiff === diffClosed) {
-      finalState = "closed";
-    } else if (minDiff === diffMiddle) {
-      finalState = "middle";
-    } else if (minDiff === diffOpen) {
-      finalState = "open";
-    }
-    setSheetState(finalState);
-    setDragging(false);
-    setStartY(null);
-    setDragHeight(null);
-  };
+      let finalState: SheetState = "middle";
+      const minDiff = Math.min(diffClosed, diffMiddle, diffOpen);
+      if (minDiff === diffClosed) {
+        finalState = "closed";
+      } else if (minDiff === diffMiddle) {
+        finalState = "middle";
+      } else if (minDiff === diffOpen) {
+        finalState = "open";
+      }
+      setSheetState(finalState);
+      setDragging(false);
+      setStartY(null);
+      setDragHeight(null);
+    },
+    [dragging, startY, startHeight, mounted]
+  );
 
   useEffect(() => {
     if (dragging) {
@@ -112,7 +118,7 @@ const BottomSheet: React.FC<BottomSheetProps> = ({ children }) => {
       document.removeEventListener("touchmove", handleDragMove);
       document.removeEventListener("touchend", handleDragEnd);
     };
-  }, [dragging, startY, startHeight, mounted]);
+  }, [dragging, handleDragMove, handleDragEnd]);
 
   const handleDragHandleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();

--- a/components/MapLoader/MapLoader.tsx
+++ b/components/MapLoader/MapLoader.tsx
@@ -81,6 +81,27 @@ export default function MapLoader({ markers }: MapLoaderProps) {
           map.setZoom(16);
         }
       }, 300); // ✅ 300ms 딜레이 후 실행 (렌더링 안정화)
+
+      const paths = markers.map(
+        (markerData) =>
+          new window.naver.maps.LatLng(
+            markerData.latitude,
+            markerData.longitude
+          )
+      );
+
+      new window.naver.maps.Polyline({
+        map: map,
+        path: paths,
+        strokeColor: "black",
+        strokeStyle: "solid",
+        strokeLineCap: "round",
+        strokeLineJoin: "round",
+        strokeWeight: 3,
+        strokeOpacity: 1.0,
+        startIcon: naver.maps.PointingIcon.DIAMOND,
+        endIcon: naver.maps.PointingIcon.BLOCK_ARROW,
+      });
     }
   }, [markers]);
 

--- a/components/MapLoader/MapLoader.tsx
+++ b/components/MapLoader/MapLoader.tsx
@@ -93,8 +93,8 @@ export default function MapLoader({ markers }: MapLoaderProps) {
       new window.naver.maps.Polyline({
         map: map,
         path: paths,
-        strokeColor: "black",
-        strokeStyle: "solid",
+        strokeColor: "var(--color-gray-1)",
+        strokeStyle: "shortdash",
         strokeLineCap: "round",
         strokeLineJoin: "round",
         strokeWeight: 3,


### PR DESCRIPTION
### 👀 관련 이슈
#146 
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용
- 바텀시트 의존성 배열에서 경고 나오는 거 해결하기 위한 코드 수정
- 순서대로 선 그리기
<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point
- 코스에서 courseEvent에 포함되는 이벤트나 순서가 변경될 때마다 markers도 재배열해서 전송 후 순서대로 Polyline 생성
- Polyline 디자인은 임의로 넣었으니까 마음에 안 들면 말해주세욥
- 그리고 MapLoader에 설정되있는 코드인 것 같은데... 순서가 변경될 때마다 첫번째로 설정되어있는 이벤트 기준으로 Map이 조정되느라 흔들림이 있는 것 같아여
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 순서 변경 시 선 그리기 | ![courseOrderEdit](https://github.com/user-attachments/assets/f0f12d6f-20f9-4943-ad48-195df4e31a31) |
