### PR TITLE
♻️ Refactor/#225 확인 버튼만 있는 Modal 추가

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -47,6 +47,8 @@ const Modal: React.FC<ModalProps> = ({
     [contents]
   );
 
+  const isAlertType = contents.some((content) => content.type === "alert");
+
   // inputFormData 변경 시 유효성 검사 실행
   useEffect(() => {
     setIsValid(validateForm(inputFormData));
@@ -64,13 +66,15 @@ const Modal: React.FC<ModalProps> = ({
           </div>
         ))}
         <div className={styles["actions"]}>
-          <button
-            type="button"
-            className={styles["cancel-btn"]}
-            onClick={handleClose}
-          >
-            {cancelText}
-          </button>
+          {!isAlertType && (
+            <button
+              type="button"
+              className={styles["cancel-btn"]}
+              onClick={handleClose}
+            >
+              {cancelText}
+            </button>
+          )}
           <button
             type="button"
             className={styles["confirm-btn"]}

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -18,11 +18,11 @@ const Modal: React.FC<ModalProps> = ({
     setInputFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setInputFormData({});
     setIsValid(false);
     onCancel();
-  };
+  }, [onCancel]);
 
   // 폼 유효성 검사
   const validateForm = useCallback(
@@ -54,10 +54,26 @@ const Modal: React.FC<ModalProps> = ({
     setIsValid(validateForm(inputFormData));
   }, [inputFormData, validateForm]);
 
+  // ESC 키 눌렀을 때 닫히지 않게 (alert만 예외)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !isAlertType) {
+        handleClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isAlertType, handleClose]);
+
   if (!isOpen) return null;
 
   return (
-    <div className={styles["modalContainer"]} onClick={handleClose}>
+    <div
+      className={styles["modalContainer"]}
+      onClick={() => {
+        if (!isAlertType) handleClose();
+      }}
+    >
       <div className={styles["modal"]} onClick={(e) => e.stopPropagation()}>
         {contents.map((content, idx) => (
           <div key={idx} className={styles["modalItem"]}>
@@ -78,9 +94,7 @@ const Modal: React.FC<ModalProps> = ({
           <button
             type="button"
             className={styles["confirm-btn"]}
-            onClick={() => {
-              onConfirm(inputFormData);
-            }}
+            onClick={() => onConfirm(inputFormData)}
             disabled={!isValid}
           >
             {confirmText}

--- a/components/modal/Modal.type.ts
+++ b/components/modal/Modal.type.ts
@@ -1,10 +1,16 @@
 export type ModalContent =
   | TextOnlyModalContent
+  | AlertModalContent
   | TextInputModalContent
   | CalendarModalContent;
 
 type TextOnlyModalContent = {
   type: "textOnly";
+  title: string;
+};
+
+type AlertModalContent = {
+  type: "alert";
   title: string;
 };
 

--- a/components/modal/ModalType.tsx
+++ b/components/modal/ModalType.tsx
@@ -27,6 +27,10 @@ const ModalType = ({ content, onChange }: ModalTypeProps) => {
     return null;
   }
 
+  if (content.type === "alert") {
+    return null;
+  }
+
   if (content.type === "text") {
     return (
       <Input


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
현재 생성한 textOnly 모달은 확인/취소만 존재

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
Alert을 대체할 확인만 존재하는 Modal 추가 구현

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
<Modal
          contents={[
            {
              type: "alert",
              title: "등록 완료 !",
            },
          ]}
          onConfirm={handleConfirm}
          onCancel={toggleModal}
          isOpen={isModalOpen}
          confirmText="확인"
      />
