### PR TITLE
✨ Feat/#227 회원가입페이지 이메일 인증 기능

### DIFF
--- a/app/(anon)/join/_components/JoinForm/JoinForm.module.scss
+++ b/app/(anon)/join/_components/JoinForm/JoinForm.module.scss
@@ -15,4 +15,9 @@
     font-size: var(--font-size-sm);
     color: rgb(240, 110, 110);
   }
+  .verificationContainer {
+    display: flex;
+    flex-direction: column;
+    gap: var(--margin-sm);
+  }
 }

--- a/app/(anon)/join/_components/JoinForm/JoinForm.tsx
+++ b/app/(anon)/join/_components/JoinForm/JoinForm.tsx
@@ -15,6 +15,7 @@ interface FormDataType {
   email: string;
   password: string;
   passwordConfirm: string;
+  verificationCode: string; // 이메일 인증 번호
 }
 
 export default function JoinForm({ setIsFormValid, onSubmit }: JoinFormProps) {
@@ -23,11 +24,22 @@ export default function JoinForm({ setIsFormValid, onSubmit }: JoinFormProps) {
     email: "",
     password: "",
     passwordConfirm: "",
+    verificationCode: "", // 이메일 인증 코드 상태 추가
   });
 
   const [isEmailValid, setIsEmailValid] = useState(false); // 이메일 중복 검사 상태
   const [emailError, setEmailError] = useState<string | null>(null); // 이메일 에러 메시지
+  const [isVerificationSent, setIsVerificationSent] = useState(false); // 이메일 인증 버튼 상태
   const [isValidForm, setIsValidForm] = useState(false); // ✅ 전체 폼 유효 상태
+  const [isEmailVerified, setIsEmailVerified] = useState(false); // 이메일 인증 여부
+  const [serverValidationCode, setServerValidationCode] = useState<
+    string | null
+  >(null); // 인증 코드
+  const [countdown, setCountdown] = useState<number>(0); // 인증 코드 유효 시간 상태
+  const [loading, setLoading] = useState<boolean>(false);
+  const [verificationCodeError, setVerificationCodeError] = useState<
+    string | null
+  >(null); // 인증 코드 에러 메시지
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
@@ -40,6 +52,25 @@ export default function JoinForm({ setIsFormValid, onSubmit }: JoinFormProps) {
     if (name === "email") {
       setIsEmailValid(false);
       setEmailError(null);
+      setCountdown(0); // 카운트다운 초기화
+      setIsVerificationSent(false); // 인증 코드 전송 초기화
+      setServerValidationCode(null);
+      setIsEmailVerified(false); // 이메일 인증 여부 초기화
+      setLoading(false);
+      setIsValidForm(false); // 폼 유효성 초기화
+      setVerificationCodeError(null); // 인증 코드 에러 초기화
+    }
+
+    // 인증 코드가 변경될 때마다 검증
+    if (name === "verificationCode" && serverValidationCode) {
+      if (value === serverValidationCode) {
+        setIsEmailVerified(true);
+        setVerificationCodeError(null); // 인증 코드 일치하면 에러 없애기
+        setCountdown(0); // 인증 코드 일치 시 카운트다운 초기화
+      } else {
+        setIsEmailVerified(false);
+        setVerificationCodeError("인증 코드가 동일하지 않습니다.");
+      }
     }
 
     checkFormValidity({ ...formData, [name]: value }, isEmailValid);
@@ -48,7 +79,7 @@ export default function JoinForm({ setIsFormValid, onSubmit }: JoinFormProps) {
   const checkFormValidity = (data: FormDataType, emailValid: boolean) => {
     const allFilled = Object.values(data).every((val) => val.trim() !== "");
     const passwordMatch = data.password === data.passwordConfirm;
-    const isValid = allFilled && emailValid && passwordMatch;
+    const isValid = allFilled && emailValid && passwordMatch && isEmailVerified;
 
     setIsFormValid(isValid);
     setIsValidForm(isValid);
@@ -92,6 +123,59 @@ export default function JoinForm({ setIsFormValid, onSubmit }: JoinFormProps) {
       }
     }
   };
+
+  // 이메일 인증 API 호출
+  const handleEmailVerification = async () => {
+    setLoading(true);
+
+    if (!isEmailValid) {
+      alert("이메일 중복 확인을 먼저 해주세요.");
+      return;
+    }
+
+    try {
+      const response = await fetch("/api/auth/join/send-email", {
+        method: "POST",
+        body: JSON.stringify({ email: formData.email }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      if (!response.ok) {
+        throw new Error("서버 오류 발생");
+      }
+
+      const data = await response.json();
+
+      // 인증 코드가 성공적으로 발송되었을 때의 처리
+      if (data.ok) {
+        alert("인증 코드가 이메일로 전송되었습니다.");
+        setServerValidationCode(data.code || ""); // 인증코드 저장
+        setCountdown(180); // 3분 카운트다운 시작
+        setLoading(false);
+      } else {
+        alert("인증 코드 발송에 실패했습니다.");
+      }
+
+      setIsVerificationSent(true);
+    } catch (error) {
+      alert("인증 코드 전송 중 오류가 발생했습니다.");
+      if (process.env.NODE_ENV === "development") {
+        console.error("🚨 인증 코드 전송 오류:", error);
+      }
+    }
+  };
+
+  // 카운트다운이 3분으로 설정되면, 1초씩 감소시키기
+  useEffect(() => {
+    let timer: NodeJS.Timeout | undefined;
+    if (countdown > 0) {
+      timer = setInterval(() => {
+        setCountdown((prev) => prev - 1);
+      }, 1000);
+    }
+    return () => clearInterval(timer);
+  }, [countdown]);
+
   // ✅ 폼이 유효해지면 부모 컴포넌트로 데이터 전달
   useEffect(() => {
     if (isValidForm) {
@@ -110,7 +194,6 @@ export default function JoinForm({ setIsFormValid, onSubmit }: JoinFormProps) {
           onChange={handleChange}
         />
       </div>
-
       <div>
         <label className={styles.label}>이메일</label>
         <div className={styles.emailValidation}>
@@ -130,6 +213,45 @@ export default function JoinForm({ setIsFormValid, onSubmit }: JoinFormProps) {
         {emailError && <p className={styles.errorText}>{emailError}</p>}{" "}
         {/* 에러 메시지 표시 */}
       </div>
+      {isEmailValid && (
+        <div className={styles.verificationContainer}>
+          <div>
+            <FlexibleButton
+              onClick={handleEmailVerification}
+              value={
+                loading
+                  ? "전송 중..."
+                  : countdown > 0
+                    ? `남은 시간: ${Math.floor(countdown / 60)}:${(
+                        countdown % 60
+                      )
+                        .toString()
+                        .padStart(2, "0")}`
+                    : isEmailVerified
+                      ? "이메일 인증 완료"
+                      : "이메일 인증 요청"
+              }
+              disabled={loading || countdown > 0 || isEmailVerified}
+            />
+          </div>
+
+          {/* 인증 코드 입력 */}
+          {!isEmailVerified && isVerificationSent && (
+            <div>
+              <Input
+                name="verificationCode"
+                type="text"
+                value={formData.verificationCode}
+                placeholder="인증 코드를 입력하세요."
+                onChange={handleChange}
+              />
+              {verificationCodeError && (
+                <p className={styles.errorText}>{verificationCodeError}</p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       <div>
         <label className={styles.label}>비밀번호</label>
@@ -141,7 +263,6 @@ export default function JoinForm({ setIsFormValid, onSubmit }: JoinFormProps) {
           onChange={handleChange}
         />
       </div>
-
       <div>
         <label className={styles.label}>비밀번호 확인</label>
         <Input

--- a/app/api/auth/join/send-email/route.ts
+++ b/app/api/auth/join/send-email/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { SendEmailUsecase } from "@/application/usecases/join/SendEmail";
+import { SendEmailDto } from "@/application/usecases/join/dto/SendEmailDto";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const email: string = body.email;
+
+    // 이메일 전송 결과를 받음
+    const sendEmail: SendEmailDto = await SendEmailUsecase(email);
+
+    // 이메일 전송 결과에 따라 응답 처리
+    if (sendEmail.ok) {
+      return NextResponse.json(sendEmail, { status: 201 });
+    } else {
+      return NextResponse.json(
+        { error: sendEmail.message || "이메일 발송에 실패했습니다." },
+        { status: 500 }
+      );
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("🚨 이메일 전송 오류:", error);
+    }
+    return NextResponse.json(
+      { error: "회원가입 중 오류가 발생했습니다." },
+      { status: 500 }
+    );
+  }
+}

--- a/application/usecases/join/SendEmail.ts
+++ b/application/usecases/join/SendEmail.ts
@@ -26,8 +26,12 @@ export const SendEmailUsecase = async (
   const mailOptions = {
     from: process.env.NODE_MAILER_ID,
     to: email,
-    subject: "[광운대학교 강의실 예약 시스템] 인증코드",
-    html: `인증번호는 <strong>${generatedCode}</strong> 이며, 만료시간 3분 내에 입력해주시길 바랍니다.`,
+    subject: "[DearDay] 회원가입 인증코드",
+    html: `
+  <h3 style="font-family: Arial, sans-serif;">인증번호: <span style="color:blue; font-size: 20px;">${generatedCode}</span></h3>
+  <p style="font-family: Arial, sans-serif;">인증번호는 <strong>3분</strong> 이내에 입력하셔야 유효합니다.</p>
+  <p style="font-family: Arial, sans-serif;">감사합니다.</p>
+`,
   };
 
   try {

--- a/application/usecases/join/SendEmail.ts
+++ b/application/usecases/join/SendEmail.ts
@@ -1,6 +1,7 @@
 import nodemailer from "nodemailer";
 import { SendEmailDto } from "./dto/SendEmailDto";
 
+// 이메일 전송을 위한 SMTP 설정
 const smtpTransport = nodemailer.createTransport({
   service: "gmail",
   auth: {
@@ -11,11 +12,12 @@ const smtpTransport = nodemailer.createTransport({
 
 const otpStorage: { [key: string]: string } = {}; // 이메일별 OTP 저장
 
+// 이메일로 인증 코드를 전송하는 함수
 export const SendEmailUsecase = async (
   email: string
 ): Promise<SendEmailDto> => {
   if (!email) {
-    return { ok: false };
+    return { ok: false, message: "이메일 주소가 필요합니다." }; // 이메일 주소가 없을 경우
   }
 
   const generatedCode = Math.floor(100000 + Math.random() * 900000).toString();
@@ -30,9 +32,13 @@ export const SendEmailUsecase = async (
 
   try {
     await smtpTransport.sendMail(mailOptions);
-    return { ok: true, code: generatedCode };
+    return {
+      ok: true,
+      code: generatedCode,
+      message: "인증 코드가 발송되었습니다.",
+    };
   } catch (error) {
-    console.error("Email sending error:", error);
-    return { ok: false };
+    console.error("이메일 발송 오류:", error);
+    return { ok: false, message: "이메일 발송에 실패했습니다." };
   }
 };

--- a/application/usecases/join/SendEmail.ts
+++ b/application/usecases/join/SendEmail.ts
@@ -1,0 +1,38 @@
+import nodemailer from "nodemailer";
+import { SendEmailDto } from "./dto/SendEmailDto";
+
+const smtpTransport = nodemailer.createTransport({
+  service: "gmail",
+  auth: {
+    user: process.env.NODE_MAILER_ID,
+    pass: process.env.NODE_MAILER_PASSWORD,
+  },
+});
+
+const otpStorage: { [key: string]: string } = {}; // 이메일별 OTP 저장
+
+export const SendEmailUsecase = async (
+  email: string
+): Promise<SendEmailDto> => {
+  if (!email) {
+    return { ok: false };
+  }
+
+  const generatedCode = Math.floor(100000 + Math.random() * 900000).toString();
+  otpStorage[email] = generatedCode; // OTP 저장
+
+  const mailOptions = {
+    from: process.env.NODE_MAILER_ID,
+    to: email,
+    subject: "[광운대학교 강의실 예약 시스템] 인증코드",
+    html: `인증번호는 <strong>${generatedCode}</strong> 이며, 만료시간 3분 내에 입력해주시길 바랍니다.`,
+  };
+
+  try {
+    await smtpTransport.sendMail(mailOptions);
+    return { ok: true, code: generatedCode };
+  } catch (error) {
+    console.error("Email sending error:", error);
+    return { ok: false };
+  }
+};

--- a/application/usecases/join/dto/SendEmailDto.ts
+++ b/application/usecases/join/dto/SendEmailDto.ts
@@ -1,0 +1,4 @@
+export interface SendEmailDto {
+  ok: boolean;
+  code?: string;
+}

--- a/application/usecases/join/dto/SendEmailDto.ts
+++ b/application/usecases/join/dto/SendEmailDto.ts
@@ -1,4 +1,5 @@
 export interface SendEmailDto {
   ok: boolean;
   code?: string;
+  message?: string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@types/jsonwebtoken": "^9.0.9",
         "@types/navermaps": "^3.7.9",
         "@types/node": "^20",
+        "@types/nodemailer": "^6.4.17",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "cross-env": "^7.0.3",
@@ -3496,6 +3497,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "jsonwebtoken": "^9.0.2",
         "next": "15.1.7",
         "next-pwa": "^5.6.0",
+        "nodemailer": "^6.10.0",
         "prettier": "^3.5.1",
         "react": "^19.0.0",
         "react-datepicker": "^8.1.0",
@@ -7758,6 +7759,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
+      "integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jsonwebtoken": "^9.0.2",
     "next": "15.1.7",
     "next-pwa": "^5.6.0",
+    "nodemailer": "^6.10.0",
     "prettier": "^3.5.1",
     "react": "^19.0.0",
     "react-datepicker": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/jsonwebtoken": "^9.0.9",
     "@types/navermaps": "^3.7.9",
     "@types/node": "^20",
+    "@types/nodemailer": "^6.4.17",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
### 👀 관련 이슈

#227

### ✨ 작업한 내용

- [nodemailer 라이브러리 설치](https://github.com/FRONT-END-BOOTCAMP-PLUS-3/dear-day/commit/700e14666a91efaf8052ad07c280c7d283a277df)
- [SendEmail 유즈케이스 및 DTO](https://github.com/FRONT-END-BOOTCAMP-PLUS-3/dear-day/commit/dbfae6f52265f4910f8471c667f6f63b5163d479)
- [send-email api생성](https://github.com/FRONT-END-BOOTCAMP-PLUS-3/dear-day/commit/0dcd1266cb5f716adae32a8388e335af2d2c3050)
- [이메일 인증 기능 추가 및 상태 관리 개선](https://github.com/FRONT-END-BOOTCAMP-PLUS-3/dear-day/commit/990868f3553f316ba200bf52ea36e65789b0dae6)

### 🌀 PR Point



### 🍰 참고사항

input이랑 버튼 관련 스타일은 추후에 변경해야 할 것 같습니닷

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 1. 이메일 입력 <br> 2. 중복 확인 <br>3. 이메일 인증<br> 4. 카운트다운 시작 및 인증코드 입력 <br>5. 인증 완료되더라도 다른 이메일을 입력하면 전부 초기화됨 | ![Apr-08-2025 13-42-42](https://github.com/user-attachments/assets/4348d57e-5aef-4784-a736-cbdac3b66037) |
